### PR TITLE
[rosemacs] fix group tags unless element setting in roslaunch.rnc

### DIFF
--- a/rosemacs/roslaunch.rnc
+++ b/rosemacs/roslaunch.rnc
@@ -3,7 +3,7 @@
 grammar {
   start = launch
   launch = element launch { master? & node* & param* & inc* & group* & rosparam* & env* & arg* & remap* }
-  group = element group { attribute ns { text }? & attribute if { text }? & attribute unless { text } &
+  group = element group { attribute ns { text }? & attribute if { text }? & attribute unless { text }? &
                          ( node* & param* & inc* ) }
   master = element master { attribute auto { text } }
   node = element node {


### PR DESCRIPTION
This will fix below wrong highlight problem by change "unless" as not must property

![group_ns](https://cloud.githubusercontent.com/assets/3803922/10782074/ac50cd7c-7d90-11e5-8ad0-13242a7c47fe.png)
